### PR TITLE
removing uneeded dependency in path_tracer.py

### DIFF
--- a/runner/path_tracer.py
+++ b/runner/path_tracer.py
@@ -15,7 +15,6 @@ import functools
 import tempfile
 import struct
 import posix
-import psutil
 
 from limiter import setlimits, RUNNING_PROCESSES
 import hybrid


### PR DESCRIPTION
Removing this dependency as it's not used. It makes the process fail inside docker as it's not included in there.